### PR TITLE
Change 'redirect' calls to 'h.redirect_to'

### DIFF
--- a/ckanext/s3archive/controller.py
+++ b/ckanext/s3archive/controller.py
@@ -8,6 +8,7 @@ import boto.s3.connection as s3connection
 
 import ckan.logic as logic
 import ckan.lib.base as base
+import ckan.lib.helpers as h
 from ckan.common import c, response, request, _
 import ckan.model as model
 import ckan.lib.uploader as uploader
@@ -20,7 +21,7 @@ NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
 render = base.render
 abort = base.abort
-redirect = base.redirect
+redirect = h.redirect_to
 get_action = logic.get_action
 
 


### PR DESCRIPTION
ckan.lib.base.redirect was removed in [1], guidance is to always use h.redirect_to instead. 

[1] ckan/ckan@34f3f18
